### PR TITLE
Major refactor and api change.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  ubuntu-adopt-jdk-11:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn package --file pom.xml
+
+  ubuntu-adopt-jdk-8:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn package --file pom.xml
+
+  ubuntu-adopt-jdk-17:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: maven
+      - name: Build with Maven
+        run: mvn package --file pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>2.7</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/palindromicity/syslog/AbstractSyslogMessageHandler.java
+++ b/src/main/java/com/github/palindromicity/syslog/AbstractSyslogMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,15 @@
  * limitations under the License.
  */
 
-package com.github.palindromicity.syslog.dsl;
 
-import java.util.Map;
+package com.github.palindromicity.syslog;
 
 /**
- * Interface for classes that provide Message Maps.
+ * Abstract base class for handling consumption of syslog messages and productions of
+ * type T from those messages.
+ *
+ * @param <T> the {@code type} this handler produces
  */
-public interface MessageMapProvider {
-
-  /**
-   * Returns a {@code Map}.
-   *
-   * @return {@code Map}
-   */
-  Map<String, Object> getMessageMap();
+public abstract class AbstractSyslogMessageHandler<T>
+    implements SyslogMessageConsumer, SyslogMessageProducer<T> {
 }

--- a/src/main/java/com/github/palindromicity/syslog/AbstractSyslogParser.java
+++ b/src/main/java/com/github/palindromicity/syslog/AbstractSyslogParser.java
@@ -4,130 +4,62 @@ import com.github.palindromicity.syslog.dsl.Syslog3164Listener;
 import com.github.palindromicity.syslog.util.Validate;
 import java.io.BufferedReader;
 import java.io.Reader;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-abstract class AbstractSyslogParser implements SyslogParser {
+abstract class AbstractSyslogParser<T> implements SyslogParser<T> {
 
   /**
-   * {@link com.github.palindromicity.syslog.KeyProvider} to provide keys.
+   * {@link SyslogMessageConsumer} for storing results.
+   *
    */
-  private KeyProvider keyProvider;
-
-  /**
-   * {@code EnumSet} of {@link AllowableDeviations}.
-   */
-  private EnumSet<AllowableDeviations> deviations;
-
-  /**
-   * {@link NilPolicy}.
-   */
-  private NilPolicy nilPolicy = NilPolicy.OMIT;
-
-  /**
-   * {@link StructuredDataPolicy}.
-   */
-  private StructuredDataPolicy structuredDataPolicy = StructuredDataPolicy.FLATTEN;
+  AbstractSyslogMessageHandler<T> syslogBuilder;
 
   /**
    * Create a new {@code AbstractSyslogParser}.
    *
-   * @param keyProvider {@link com.github.palindromicity.syslog.KeyProvider} to provide keys for the
-   *                    {@link Syslog3164Listener}.
-   * @param deviations  {@link AllowableDeviations} for parsing
+   * @param syslogBuilder {@link AbstractSyslogMessageHandler} used gather data
    */
-  AbstractSyslogParser(KeyProvider keyProvider, EnumSet<AllowableDeviations> deviations) {
-    Validate.notNull(keyProvider, "keyProvider");
-    this.keyProvider = keyProvider;
-    this.deviations = deviations;
+  AbstractSyslogParser(AbstractSyslogMessageHandler<T> syslogBuilder) {
+    Validate.notNull(syslogBuilder, "syslogBuilder");
+    this.syslogBuilder = syslogBuilder;
   }
 
   /**
-   * Create a new {@code AbstractSyslogParser}.
+   * Get the {@link SyslogMessageConsumer}.
    *
-   * @param keyProvider          {@link com.github.palindromicity.syslog.KeyProvider} to
-   *                             provide keys for the {@link Syslog3164Listener}.
-   * @param deviations           {@link AllowableDeviations} for parsing
-   * @param nilPolicy            {@link NilPolicy}
-   * @param structuredDataPolicy {@link StructuredDataPolicy}
+   * @return {@link SyslogMessageConsumer}
    */
-  AbstractSyslogParser(KeyProvider keyProvider, EnumSet<AllowableDeviations> deviations,
-                       NilPolicy nilPolicy, StructuredDataPolicy structuredDataPolicy) {
-    Validate.notNull(keyProvider, "keyProvider");
-    this.keyProvider = keyProvider;
-    this.deviations = deviations;
-    if (nilPolicy != null) {
-      this.nilPolicy = nilPolicy;
-    }
-    if (structuredDataPolicy != null) {
-      this.structuredDataPolicy = structuredDataPolicy;
-    }
-  }
-
-  /**
-   * Get the {@link KeyProvider}.
-   *
-   * @return {@link KeyProvider}
-   */
-  KeyProvider getKeyProvider() {
-    return keyProvider;
-  }
-
-  /**
-   * Get the {@link AllowableDeviations}.
-   *
-   * @return {@code EnumSet} of {@link AllowableDeviations}
-   */
-  EnumSet<AllowableDeviations> getDeviations() {
-    return deviations;
-  }
-
-  /**
-   * Get the {@link NilPolicy}.
-   *
-   * @return {@link NilPolicy}
-   */
-  NilPolicy getNilPolicy() {
-    return nilPolicy;
-  }
-
-  /**
-   * Get the {@link StructuredDataPolicy}.
-   *
-   * @return {@link StructuredDataPolicy}
-   */
-  StructuredDataPolicy getStructuredDataPolicy() {
-    return structuredDataPolicy;
+  AbstractSyslogMessageHandler<T> getSyslogBuilder() {
+    return syslogBuilder;
   }
 
   @Override
-  public abstract Map<String, Object> parseLine(String syslogLine);
+  public abstract T parseLine(String syslogLine);
 
   @Override
-  public void parseLine(String line, Consumer<Map<String, Object>> consumer) {
+  public void parseLine(String line, Consumer<T> consumer) {
     Validate.notNull(consumer, "consumer");
     consumer.accept(parseLine(line));
   }
 
   @Override
-  public List<Map<String, Object>> parseLines(Reader reader) {
+  public List<T> parseLines(Reader reader) {
     Validate.notNull(reader, "reader");
     return new BufferedReader(reader).lines().map(this::parseLine).collect(Collectors.toList());
   }
 
   @Override
-  public void parseLines(Reader reader, Consumer<Map<String, Object>> consumer) {
+  public void parseLines(Reader reader, Consumer<T> consumer) {
     Validate.notNull(reader, "reader");
     Validate.notNull(consumer, "consumer");
     new BufferedReader(reader).lines().map(this::parseLine).forEach(consumer);
   }
 
   @Override
-  public void parseLines(Reader reader, Consumer<Map<String, Object>> messageConsumer,
+  public void parseLines(Reader reader, Consumer<T> messageConsumer,
                          BiConsumer<String, Throwable> errorConsumer) {
     Validate.notNull(reader, "reader");
     Validate.notNull(reader, "messageConsumer");

--- a/src/main/java/com/github/palindromicity/syslog/AllowableDeviations.java
+++ b/src/main/java/com/github/palindromicity/syslog/AllowableDeviations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/Default3164MessageHandler.java
+++ b/src/main/java/com/github/palindromicity/syslog/Default3164MessageHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 simple-syslog authors
+ * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.palindromicity.syslog;
+
+import com.github.palindromicity.syslog.dsl.ParseException;
+import com.github.palindromicity.syslog.dsl.SyslogFieldKeys;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+
+public class Default3164MessageHandler
+    extends AbstractSyslogMessageHandler<Map<String, String>> {
+
+  /**
+   * {@link KeyProvider} that provides our key names.
+   */
+  private KeyProvider keyProvider;
+
+  /**
+   * {@link AllowableDeviations} for parsing and errors.
+   */
+  private final EnumSet<AllowableDeviations> deviations;
+
+  final Map<String, String> map = new HashMap<>();
+
+
+  /**
+   * Create a new {@code MapOfMaps3164Builder}.
+   */
+  public Default3164MessageHandler() {
+    this(null, EnumSet.of(AllowableDeviations.NONE));
+  }
+
+  /**
+   * Create a new {@code MapOfMaps3164Builder}.
+   *
+   * @param keyProvider {@link KeyProvider} used for map insertion and lookup.
+   */
+  public Default3164MessageHandler(KeyProvider keyProvider) {
+    this(keyProvider, EnumSet.of(AllowableDeviations.NONE));
+  }
+
+  /**
+   * Create a new {@code MapOfMaps3164Builder}.
+   *
+   * @param keyProvider {@link KeyProvider} used for map insertion.
+   * @param deviations  {@link AllowableDeviations} used for handling abnormalities.
+   */
+  public Default3164MessageHandler(KeyProvider keyProvider,
+                                   EnumSet<AllowableDeviations> deviations) {
+    if (keyProvider == null) {
+      this.keyProvider = new DefaultKeyProvider();
+    } else {
+      this.keyProvider = keyProvider;
+    }
+    this.deviations = deviations;
+  }
+
+  @Override
+  public void consumeValue(SyslogFieldKeys key, String value) {
+    map.put(keyProvider.get(key), value);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void consumeStructured(String id, Map<String, String> rawParameterMap) {
+  }
+
+  @Override
+  public Map<String, String> produce() {
+    if (map.get(keyProvider.getHeaderPriority()) == null && !deviations
+        .contains(AllowableDeviations.PRIORITY)) {
+      throw new ParseException("Priority missing with strict parsing");
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public void start() {
+    this.map.clear();
+  }
+
+  @Override
+  public void complete() {
+  }
+
+  @Override
+  public void reset() {
+    this.map.clear();
+  }
+
+  @Override
+  public void handleNil(SyslogFieldKeys key) {
+  }
+}

--- a/src/main/java/com/github/palindromicity/syslog/DefaultKeyProvider.java
+++ b/src/main/java/com/github/palindromicity/syslog/DefaultKeyProvider.java
@@ -16,6 +16,11 @@ public class DefaultKeyProvider implements KeyProvider {
       .compile(SyslogFieldKeys.STRUCTURED_ELEMENT_ID_PNAME_PATTERN.getField());
 
   @Override
+  public String get(SyslogFieldKeys keys) {
+    return keys.getField();
+  }
+
+  @Override
   public String getMessage() {
     return SyslogFieldKeys.MESSAGE.getField();
   }

--- a/src/main/java/com/github/palindromicity/syslog/Flat5424MessageHandler.java
+++ b/src/main/java/com/github/palindromicity/syslog/Flat5424MessageHandler.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 simple-syslog authors
+ * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.palindromicity.syslog;
+
+import com.github.palindromicity.syslog.dsl.ParseException;
+import com.github.palindromicity.syslog.dsl.SyslogFieldKeys;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Flat5424MessageHandler extends AbstractSyslogMessageHandler<Map<String, String>> {
+  private static final String DASH = "-";
+
+  /**
+   * {@link KeyProvider} that provides our key names.
+   */
+  private final KeyProvider keyProvider;
+
+  /**
+   * {@link NilPolicy} for parsing.
+   */
+  NilPolicy nilPolicy = NilPolicy.OMIT;
+
+  /**
+   * {@link AllowableDeviations} for parsing and errors.
+   */
+  private final EnumSet<AllowableDeviations> deviations;
+
+  final Map<String, String> map = new HashMap<>();
+
+
+  /**
+   * Create a new {@code Flat5424Builder}.
+   */
+  public Flat5424MessageHandler() {
+    this(null, null, EnumSet.of(AllowableDeviations.NONE));
+  }
+
+  /**
+   * Create a new {@code Flat5424Builder}.
+   *
+   * @param keyProvider {@link KeyProvider} used for map insertion and lookup.
+   * @param nilPolicy   {@link NilPolicy} used for handling nil values.
+   */
+  public Flat5424MessageHandler(KeyProvider keyProvider, NilPolicy nilPolicy) {
+    this(keyProvider, nilPolicy, EnumSet.of(AllowableDeviations.NONE));
+  }
+
+  /**
+   * Create a new {@code Flat5424Builder}.
+   *
+   * @param keyProvider {@link KeyProvider} used for map insertion.
+   * @param nilPolicy   {@link NilPolicy} used for handling nil values.
+   *                    output.
+   * @param deviations  {@link AllowableDeviations} used for handling abnormalities.
+   */
+  public Flat5424MessageHandler(KeyProvider keyProvider, NilPolicy nilPolicy,
+                                EnumSet<AllowableDeviations> deviations) {
+    if (keyProvider == null) {
+      this.keyProvider = new DefaultKeyProvider();
+    } else {
+      this.keyProvider = keyProvider;
+    }
+
+    if (nilPolicy != null) {
+      this.nilPolicy = nilPolicy;
+    }
+
+    this.deviations = deviations;
+  }
+
+  @Override
+  public void consumeValue(SyslogFieldKeys key, String value) {
+    map.put(keyProvider.get(key), value);
+  }
+
+  @Override
+  public void consumeStructured(String id, Map<String, String> rawParameterMap) {
+    for (Map.Entry<String, String> entry : rawParameterMap.entrySet()) {
+      map.put(String.format(keyProvider.getStructuredElementIdParamNameFormat(), (id),
+          entry.getKey()), entry.getValue());
+    }
+  }
+
+  @Override
+  public Map<String, String> produce() {
+    if (map.get(keyProvider.getHeaderPriority()) == null && !deviations
+        .contains(AllowableDeviations.PRIORITY)) {
+      throw new ParseException("Priority missing with strict parsing");
+    } else if (map.get(keyProvider.getHeaderVersion()) == null && !deviations
+        .contains(AllowableDeviations.VERSION)) {
+      throw new ParseException("Version missing with strict parsing");
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public void start() {
+    this.map.clear();
+  }
+
+  @Override
+  public void complete() {
+  }
+
+  @Override
+  public void reset() {
+    this.map.clear();
+  }
+
+  @Override
+  public void handleNil(SyslogFieldKeys key) {
+    if (this.nilPolicy == NilPolicy.OMIT) {
+      return;
+    }
+    if (this.nilPolicy == NilPolicy.DASH) {
+      map.put(keyProvider.get(key), DASH);
+    } else if (this.nilPolicy == NilPolicy.NULL) {
+      map.put(keyProvider.get(key), null);
+    }
+  }
+}

--- a/src/main/java/com/github/palindromicity/syslog/KeyProvider.java
+++ b/src/main/java/com/github/palindromicity/syslog/KeyProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.github.palindromicity.syslog;
 
+import com.github.palindromicity.syslog.dsl.SyslogFieldKeys;
 import java.util.regex.Pattern;
 
 /**
@@ -23,6 +24,14 @@ import java.util.regex.Pattern;
  * Map keys used for Syslog message parts. Some keys only apply to certain RFCs
  */
 public interface KeyProvider {
+
+  /**
+   * Provides the key name for a given SyslogFieldKeys.
+   *
+   * @param key {@code SyslogFieldKeys}
+   * @return the key name corresponding to the passed SyslogFieldKeys
+   */
+  String get(SyslogFieldKeys key);
 
   /**
    * Provides the key name for the MSG @see <a href="https://tools.ietf.org/html/rfc5424#section-6.4">Section 6.4</a>.

--- a/src/main/java/com/github/palindromicity/syslog/MapOfMaps5424MessageHandler.java
+++ b/src/main/java/com/github/palindromicity/syslog/MapOfMaps5424MessageHandler.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 simple-syslog authors
+ * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.palindromicity.syslog;
+
+import com.github.palindromicity.syslog.dsl.ParseException;
+import com.github.palindromicity.syslog.dsl.SyslogFieldKeys;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class MapOfMaps5424MessageHandler
+    extends AbstractSyslogMessageHandler<Map<String, Object>> {
+  private static final String DASH = "-";
+
+  /**
+   * {@link KeyProvider} that provides our key names.
+   */
+  private KeyProvider keyProvider;
+
+  /**
+   * {@link NilPolicy} for parsing.
+   */
+  NilPolicy nilPolicy = NilPolicy.OMIT;
+
+  /**
+   * {@link AllowableDeviations} for parsing and errors.
+   */
+  private final EnumSet<AllowableDeviations> deviations;
+
+  final Map<String, Object> map = new HashMap<>();
+
+
+  /**
+   * Create a new {@code MapOfMaps5424Builder}.
+   */
+  public MapOfMaps5424MessageHandler() {
+    this(null, null, EnumSet.of(AllowableDeviations.NONE));
+  }
+
+  /**
+   * Create a new {@code MapOfMaps5424Builder}.
+   *
+   * @param keyProvider {@link KeyProvider} used for map insertion and lookup.
+   * @param nilPolicy   {@link NilPolicy} used for handling nil values.
+   */
+  public MapOfMaps5424MessageHandler(KeyProvider keyProvider, NilPolicy nilPolicy) {
+    this(keyProvider, nilPolicy, EnumSet.of(AllowableDeviations.NONE));
+  }
+
+  /**
+   * Create a new {@code MapOfMaps5424Builder}.
+   *
+   * @param keyProvider {@link KeyProvider} used for map insertion.
+   * @param nilPolicy   {@link NilPolicy} used for handling nil values.
+   *                    output.
+   * @param deviations  {@link AllowableDeviations} used for handling abnormalities.
+   */
+  public MapOfMaps5424MessageHandler(KeyProvider keyProvider, NilPolicy nilPolicy,
+                                     EnumSet<AllowableDeviations> deviations) {
+    if (keyProvider == null) {
+      this.keyProvider = new DefaultKeyProvider();
+    } else {
+      this.keyProvider = keyProvider;
+    }
+
+    if (nilPolicy != null) {
+      this.nilPolicy = nilPolicy;
+    }
+
+    this.deviations = deviations;
+  }
+
+  @Override
+  public void consumeValue(SyslogFieldKeys key, String value) {
+    map.put(keyProvider.get(key), value);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public void consumeStructured(String id, Map<String, String> rawParameterMap) {
+    map.putIfAbsent(keyProvider.getStructuredBase(), new HashMap<String, Object>());
+    Map<String, Object> paramMap = new HashMap<>(rawParameterMap);
+    ((Map<String, Object>) map.get(keyProvider.getStructuredBase())).put(id, paramMap);
+  }
+
+  @Override
+  public Map<String, Object> produce() {
+    if (map.get(keyProvider.getHeaderPriority()) == null && !deviations
+        .contains(AllowableDeviations.PRIORITY)) {
+      throw new ParseException("Priority missing with strict parsing");
+    } else if (map.get(keyProvider.getHeaderVersion()) == null && !deviations
+        .contains(AllowableDeviations.VERSION)) {
+      throw new ParseException("Version missing with strict parsing");
+    }
+    return Collections.unmodifiableMap(map);
+  }
+
+  @Override
+  public void start() {
+    this.map.clear();
+  }
+
+  @Override
+  public void complete() {
+  }
+
+  @Override
+  public void reset() {
+    this.map.clear();
+  }
+
+  @Override
+  public void handleNil(SyslogFieldKeys key) {
+    if (this.nilPolicy == NilPolicy.OMIT) {
+      return;
+    }
+    if (this.nilPolicy == NilPolicy.DASH) {
+      map.put(keyProvider.get(key), DASH);
+    } else if (this.nilPolicy == NilPolicy.NULL) {
+      map.put(keyProvider.get(key), null);
+    }
+  }
+}

--- a/src/main/java/com/github/palindromicity/syslog/NilPolicy.java
+++ b/src/main/java/com/github/palindromicity/syslog/NilPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/Simple.java
+++ b/src/main/java/com/github/palindromicity/syslog/Simple.java
@@ -1,0 +1,253 @@
+package com.github.palindromicity.syslog;
+
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class Simple {
+  /**
+   * Parse a RFC 5424 {@code String} to a {@code Map<String, Object}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations<\p>
+   *
+   * @param line the line of 5424 Syslog to parse
+   * @return a {@code Map<String, Object}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   */
+  public static Map<String, Object> simpleNested5424(String line) {
+    SyslogParser<Map<String, Object>> parser =
+        new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(
+            new MapOfMaps5424MessageHandler()).build();
+    return parser.parseLine(line);
+  }
+
+  /**
+   * Parse a RFC 5424 {@code String} to a {@code Map<String, Object} and provides that {@code T}
+   * to the provided {@code Consumer}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations<\p>
+   *
+   * @param line     the line of 5424 Syslog to parser
+   * @param consumer the {@code Consumer}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   */
+  public static void simpleNested5424(String line, Consumer<Map<String, Object>> consumer) {
+    SyslogParser<Map<String, Object>> parser =
+        new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(
+            new MapOfMaps5424MessageHandler()).build();
+    parser.parseLine(line, consumer);
+  }
+
+  /**
+   * Reads each line RFC 5424 from the {@code Reader} and parses it to
+   * a {@code List} of {@code Map<String, Object>}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations**</p>
+   *
+   * @param reader {@code Reader} used.  It is not closed in this method.
+   * @return {@code List} of {@code Map<String, Object>}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   * @throws IllegalArgumentException                            if reader is null
+   */
+  public static List<Map<String, Object>> simpleNested5424(Reader reader) {
+    SyslogParser<Map<String, Object>> parser =
+        new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(
+            new MapOfMaps5424MessageHandler()).build();
+    return parser.parseLines(reader);
+  }
+
+  /**
+   * Reads each line of RFC 5424 from the {@code Reader} and parses it
+   * to {@code Map<String, Object>}, which is passed to the provided {@code Consumer}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations**</p>
+   *
+   * @param reader   {@code Reader} used.  It is not closed in this method.
+   * @param consumer the {@code Consumer}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   * @throws IllegalArgumentException                            if reader or consumer are null
+   */
+  public static void simpleNested5424(Reader reader, Consumer<Map<String, Object>> consumer) {
+    SyslogParser<Map<String, Object>> parser =
+        new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(
+            new MapOfMaps5424MessageHandler()).build();
+    parser.parseLines(reader, consumer);
+  }
+
+  /**
+   * Parse a RFC 5424 {@code String} to a {@code Map<String, Object>}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations<\p>
+   *
+   * @param line the line of 5424 Syslog to parse
+   * @return a {@code Map<String, Object>}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   */
+  public static Map<String, String> simpleFlat5424(String line) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().withSyslogBuilder(
+            new Flat5424MessageHandler()).build();
+    return parser.parseLine(line);
+  }
+
+  /**
+   * Parse a RFC 5424 {@code String} to a {@code Map<String, String} and provides that {@code T}
+   * to the provided {@code Consumer}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations<\p>
+   *
+   * @param line     the line of 5424 Syslog to parser
+   * @param consumer the {@code Consumer}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   */
+  public static void simpleFlat5424(String line, Consumer<Map<String, String>> consumer) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().withSyslogBuilder(
+            new Flat5424MessageHandler()).build();
+    parser.parseLine(line, consumer);
+  }
+
+  /**
+   * Reads each line of RFC 5424 from the {@code Reader} and parses it
+   * to a {@code List} of {@code Map<String, String>}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations*<\p>
+   *
+   * @param reader {@code Reader} used.  It is not closed in this method.
+   * @return {@code List} of {@code Map<String, String>}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   * @throws IllegalArgumentException                            if reader is null
+   */
+  public static List<Map<String, String>> simpleFlat5424(Reader reader) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().withSyslogBuilder(
+            new Flat5424MessageHandler()).build();
+    return parser.parseLines(reader);
+  }
+
+  /**
+   * Reads each line of RFC 5424 from the {@code Reader} and parses it
+   * to {@code Map<String, String>}, which is passed to the
+   * provided {@code Consumer}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * {@code NilPolicy.OMIT}
+   * No Deviations<\p>
+   *
+   * @param reader   {@code Reader} used.  It is not closed in this method.
+   * @param consumer the {@code Consumer}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   * @throws IllegalArgumentException                            if reader or consumer are null
+   */
+  public static void simpleFlat5424(Reader reader, Consumer<Map<String, String>> consumer) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().withSyslogBuilder(
+            new Flat5424MessageHandler()).build();
+    parser.parseLines(reader, consumer);
+  }
+
+  /**
+   * Parse a RFC 3164 {@code String} to a {@code Map<String, String}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * No Deviations<\p>
+   *
+   * @param line the line of Syslog to parse
+   * @return a {@code T}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   */
+  public static Map<String, String> simple3164(String line) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().forSpecification(
+                SyslogSpecification.RFC_3164).withSyslogBuilder(new Default3164MessageHandler())
+            .build();
+    return parser.parseLine(line);
+  }
+
+  /**
+   * Parse a RFC 3164 {@code String} to a {@code Map<String, String} and provides that {@code T}
+   * to the provided {@code Consumer}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * No Deviations</p>
+   *
+   * @param line     the line of 3164 Syslog to parser
+   * @param consumer the {@code Consumer}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   */
+  public static void simple3164(String line, Consumer<Map<String, String>> consumer) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().forSpecification(
+                SyslogSpecification.RFC_3164).withSyslogBuilder(new Default3164MessageHandler())
+            .build();
+    parser.parseLine(line, consumer);
+  }
+
+  /**
+   * Reads each line of RFC 3164 from the {@code Reader} and parses it
+   * to a {@code List} of {@code Map<String, String>}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * No Deviations*<\p>
+   *
+   * @param reader {@code Reader} used.  It is not closed in this method.
+   * @return {@code List} of {@code Map<String, String>}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   * @throws IllegalArgumentException                            if reader is null
+   */
+  public static List<Map<String, String>> simple3164(Reader reader) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().forSpecification(
+                SyslogSpecification.RFC_3164).withSyslogBuilder(new Default3164MessageHandler())
+            .build();
+    return parser.parseLines(reader);
+  }
+
+  /**
+   * Reads each line from the {@code Reader} and parses it
+   * to {@code Map<String, String>}, which is passed to the
+   * provided {@code Consumer}.
+   *
+   * <p>Uses:
+   * {@code DefaultKeyProvider}
+   * No Deviations<\p>
+   *
+   * @param reader   {@code Reader} used.  It is not closed in this method.
+   * @param consumer the {@code Consumer}
+   * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
+   * @throws IllegalArgumentException                            if reader or consumer are null
+   */
+  public static void simple3164(Reader reader, Consumer<Map<String, String>> consumer) {
+    SyslogParser<Map<String, String>> parser =
+        new SyslogParserBuilder<Map<String, String>>().forSpecification(
+                SyslogSpecification.RFC_3164).withSyslogBuilder(new Default3164MessageHandler())
+            .build();
+    parser.parseLines(reader, consumer);
+  }
+}

--- a/src/main/java/com/github/palindromicity/syslog/SyslogMessageConsumer.java
+++ b/src/main/java/com/github/palindromicity/syslog/SyslogMessageConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 simple-syslog authors
+ * Copyright 2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,27 @@
 
 package com.github.palindromicity.syslog;
 
+import com.github.palindromicity.syslog.dsl.SyslogFieldKeys;
+import java.util.Map;
+import java.util.function.Supplier;
+
 /**
- * Policy for the handling of StructuredData.
+ * SyslogMessageConsumer Interface.
+ *
+ * <p>SyslogMessageConsumer instances are called with data
+ * as it is parsed.</p>
  */
-public enum StructuredDataPolicy {
-  /**
-   * The Structured Data will be flattened per the KeyProvider provided values.
-   */
-  FLATTEN,
-  /**
-   * The Structured Data will be returned as a Map field named structuredData.
-   * Each map entry will have the value of the Structured Data ID, and a value
-   * of a map of each element param name and value
-   */
-  MAP_OF_MAPS
+public interface SyslogMessageConsumer {
+
+  void consumeValue(SyslogFieldKeys key, String value);
+
+  void consumeStructured(String id, Map<String, String> rawParameterMap);
+
+  void handleNil(SyslogFieldKeys key);
+
+  void start();
+
+  void complete();
+
+  void reset();
 }

--- a/src/main/java/com/github/palindromicity/syslog/SyslogMessageProducer.java
+++ b/src/main/java/com/github/palindromicity/syslog/SyslogMessageProducer.java
@@ -17,17 +17,14 @@
 package com.github.palindromicity.syslog;
 
 /**
- * Policy for the handling of StructuredData.
+ * Interface for classes that produce Message Objects.
  */
-public enum StructuredDataPolicy {
+public interface SyslogMessageProducer<T> {
+
   /**
-   * The Structured Data will be flattened per the KeyProvider provided values.
+   * Returns a {@code T}.
+   *
+   * @return {@code T}
    */
-  FLATTEN,
-  /**
-   * The Structured Data will be returned as a Map field named structuredData.
-   * Each map entry will have the value of the Structured Data ID, and a value
-   * of a map of each element param name and value
-   */
-  MAP_OF_MAPS
+  T produce();
 }

--- a/src/main/java/com/github/palindromicity/syslog/SyslogParser.java
+++ b/src/main/java/com/github/palindromicity/syslog/SyslogParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,46 +18,45 @@ package com.github.palindromicity.syslog;
 
 import java.io.Reader;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
  * {@code SyslogParser} defines an interface for classes that parse Syslog into {@code Map}.
  */
-public interface SyslogParser {
+public interface SyslogParser<T> {
 
   /**
-   * Parse a {@code String} to a {@code Map}.
+   * Parse a {@code String} to a {@code T}.
    *
    * @param line the line of Syslog to parse
-   * @return a {@code Map}
+   * @return a {@code T}
    * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
    */
-  Map<String, Object> parseLine(String line);
+  T parseLine(String line);
 
   /**
-   * Parse a {@code String} to a {@code Map} and provides that {@code Map}
+   * Parse a {@code String} to a {@code Map} and provides that {@code T}
    * to the provided {@code Consumer}.
    *
    * @param line     the line of Syslog to parser
    * @param consumer the {@code Consumer}
    * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
    */
-  void parseLine(String line, Consumer<Map<String, Object>> consumer);
+  void parseLine(String line, Consumer<T> consumer);
 
   /**
-   * Reads each line from the {@code Reader} and parses it to a {@code List} of {@code Map}.
+   * Reads each line from the {@code Reader} and parses it to a {@code List} of {@code T}.
    *
    * @param reader {@code Reader} used.  It is not closed in this method.
    * @return {@code List} of {@code Map}
    * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
    * @throws IllegalArgumentException                            if reader is null
    */
-  List<Map<String, Object>> parseLines(Reader reader);
+  List<T> parseLines(Reader reader);
 
   /**
-   * Reads each line from the {@code Reader} and parses it to {@code Map}, which is passed to the
+   * Reads each line from the {@code Reader} and parses it to {@code T}, which is passed to the
    * provided {@code Consumer}.
    *
    * @param reader   {@code Reader} used.  It is not closed in this method.
@@ -65,10 +64,10 @@ public interface SyslogParser {
    * @throws com.github.palindromicity.syslog.dsl.ParseException if there is an error parsing
    * @throws IllegalArgumentException                            if reader or consumer are null
    */
-  void parseLines(Reader reader, Consumer<Map<String, Object>> consumer);
+  void parseLines(Reader reader, Consumer<T> consumer);
 
   /**
-   * Reads each line from the {@code Reader} and parses it to {@code Map}, which is passed to the
+   * Reads each line from the {@code Reader} and parses it to {@code T}, which is passed to the
    * provided {@code Consumer}. For any line where a {@code ParseException} would be thrown, it will
    * will be passed to the errorConsumer.
    *
@@ -77,6 +76,6 @@ public interface SyslogParser {
    * @param errorConsumer   the {@code Consumer} for syslog lines and their errors.
    * @throws IllegalArgumentException if reader, messageConsumer, or errorConsumer are null
    */
-  void parseLines(Reader reader, Consumer<Map<String, Object>> messageConsumer,
+  void parseLines(Reader reader, Consumer<T> messageConsumer,
                   BiConsumer<String, Throwable> errorConsumer);
 }

--- a/src/main/java/com/github/palindromicity/syslog/SyslogParserBuilder.java
+++ b/src/main/java/com/github/palindromicity/syslog/SyslogParserBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,32 +16,14 @@
 
 package com.github.palindromicity.syslog;
 
-import java.util.EnumSet;
-
 /**
  * Builder for SyslogParser instances.
  */
-public class SyslogParserBuilder {
-
+public class SyslogParserBuilder<T> {
   /**
-   * The {@link AllowableDeviations}. Defaults to {@link AllowableDeviations#NONE}
+   * The {@link SyslogMessageConsumer}.
    */
-  private EnumSet<AllowableDeviations> deviations = EnumSet.of(AllowableDeviations.NONE);
-
-  /**
-   * The {@link KeyProvider}. Defaults to {@link DefaultKeyProvider}
-   */
-  private KeyProvider keyProvider = new DefaultKeyProvider();
-
-  /**
-   * The {@link NilPolicy}. Defaults to {@link NilPolicy#OMIT}
-   */
-  private NilPolicy nilPolicy = NilPolicy.OMIT;
-
-  /**
-   * The {@link StructuredDataPolicy}. Defaults to {@link StructuredDataPolicy#FLATTEN}
-   */
-  private StructuredDataPolicy structuredDataPolicy = StructuredDataPolicy.FLATTEN;
+  private AbstractSyslogMessageHandler<T> syslogBuilder;
 
   /**
    * The {@link SyslogSpecification}. Defaults to {@link SyslogSpecification#RFC_5424}
@@ -55,48 +37,16 @@ public class SyslogParserBuilder {
    *                      or {@link SyslogSpecification#RFC_3164}
    * @return {@code SyslogParserBuilder}
    */
-  public SyslogParserBuilder forSpecification(SyslogSpecification specification) {
+  public SyslogParserBuilder<T> forSpecification(SyslogSpecification specification) {
     this.specification = specification;
     return this;
   }
 
-  /**
-   * Add a {@link AllowableDeviations} to the builder.
-   *
-   * @param deviations the deviations
-   * @return {@code SyslogParserBuilder}
-   */
-  public SyslogParserBuilder withDeviations(final EnumSet<AllowableDeviations> deviations) {
-    this.deviations = deviations;
+  public SyslogParserBuilder<T> withSyslogBuilder(AbstractSyslogMessageHandler<T> syslogBuilder) {
+    this.syslogBuilder = syslogBuilder;
     return this;
   }
 
-  /**
-   * Add a {@link KeyProvider} to the builder.
-   *
-   * @param keyProvider the {@link KeyProvider}
-   * @return {@code SyslogParserBuilder}
-   */
-  public SyslogParserBuilder withKeyProvider(final KeyProvider keyProvider) {
-    this.keyProvider = keyProvider;
-    return this;
-  }
-
-  /**
-   * Set the {@link NilPolicy} to the builder.
-   *
-   * @param nilPolicy the {@link NilPolicy}
-   * @return {@code SyslogParserBuilder}
-   */
-  public SyslogParserBuilder withNilPolicy(NilPolicy nilPolicy) {
-    this.nilPolicy = nilPolicy;
-    return this;
-  }
-
-  public SyslogParserBuilder withStructuredDataPolicy(StructuredDataPolicy structuredDataPolicy) {
-    this.structuredDataPolicy = structuredDataPolicy;
-    return this;
-  }
 
   /**
    * Builds a new {@link SyslogParser} instance using options if provided.
@@ -104,18 +54,17 @@ public class SyslogParserBuilder {
    * @return {@link SyslogParser}
    * @throws IllegalStateException if deviations is unknown
    */
-  public SyslogParser build() {
-    SyslogParser parser = null;
+  public SyslogParser<T> build() {
+    SyslogParser<T> parser = null;
     switch (specification) {
       case RFC_5424:
       case RFC_6587_5424:
       case HEROKU_HTTPS_LOG_DRAIN:
-        parser = new Rfc5424SyslogParser(keyProvider, nilPolicy, structuredDataPolicy,
-            deviations, specification);
+        parser = new Rfc5424SyslogParser<T>(syslogBuilder, specification);
         break;
       case RFC_3164:
       case RFC_6587_3164:
-        parser = new Rfc3164SyslogParser(keyProvider, deviations, specification);
+        parser = new Rfc3164SyslogParser<T>(syslogBuilder, specification);
         break;
       default:
         throw new IllegalStateException("unknown specification");

--- a/src/main/java/com/github/palindromicity/syslog/SyslogSpecification.java
+++ b/src/main/java/com/github/palindromicity/syslog/SyslogSpecification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/DefaultErrorListener.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/DefaultErrorListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/DefaultErrorStrategy.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/DefaultErrorStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/ParseException.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/ParseException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/Syslog5424Listener.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/Syslog5424Listener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,19 +16,15 @@
 
 package com.github.palindromicity.syslog.dsl;
 
-import com.github.palindromicity.syslog.AllowableDeviations;
 import com.github.palindromicity.syslog.KeyProvider;
 import com.github.palindromicity.syslog.NilPolicy;
-import com.github.palindromicity.syslog.StructuredDataPolicy;
+import com.github.palindromicity.syslog.SyslogMessageConsumer;
 import com.github.palindromicity.syslog.dsl.generated.Rfc5424BaseListener;
 import com.github.palindromicity.syslog.dsl.generated.Rfc5424Listener;
 import com.github.palindromicity.syslog.dsl.generated.Rfc5424Parser;
 import com.github.palindromicity.syslog.util.Validate;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Supplier;
 
 /**
  * Simple implementation of {@link Rfc5424Listener}.
@@ -42,224 +38,107 @@ import java.util.function.Supplier;
  * the map.
  * </p>
  */
-public class Syslog5424Listener extends Rfc5424BaseListener implements MessageMapProvider {
-
-  private static final String DASH = "-";
+public class Syslog5424Listener extends Rfc5424BaseListener {
 
   /**
-   * {@link KeyProvider} that provides our key names.
+   * {@link SyslogMessageConsumer} for storing results.
    */
-  private KeyProvider keyProvider;
-
-  /**
-   * {@link NilPolicy} for parsing.
-   */
-  private NilPolicy nilPolicy = NilPolicy.OMIT;
-
-  /**
-   * {@link StructuredDataPolicy} for parsing.
-   */
-  private StructuredDataPolicy structuredDataPolicy = StructuredDataPolicy.FLATTEN;
-
-  /**
-   * {@link AllowableDeviations} for parsing and errors.
-   */
-  private EnumSet<AllowableDeviations> deviations;
-
-  /**
-   * The {@code Map} used to store our syslog values.
-   */
-  private final Map<String, Object> msgMap = new HashMap<>();
+  SyslogMessageConsumer syslogBuilder;
 
   /**
    * Create a new {@code Syslog5424Listener}.
    *
-   * @param keyProvider {@link KeyProvider} used for map insertion.
+   * @param syslogBuilder {@link SyslogMessageConsumer} used gather data
    */
-  public Syslog5424Listener(KeyProvider keyProvider) {
-    this(keyProvider, null, null, EnumSet.of(AllowableDeviations.NONE));
-  }
-
-  /**
-   * Create a new {@code Syslog5424Listener}.
-   *
-   * @param keyProvider          {@link KeyProvider} used for map insertion.
-   * @param nilPolicy            {@link NilPolicy} used for handling nil values.
-   * @param structuredDataPolicy {@link StructuredDataPolicy} used for handling Structured Data
-   *                                                        output.
-   */
-  public Syslog5424Listener(KeyProvider keyProvider, NilPolicy nilPolicy,
-                            StructuredDataPolicy structuredDataPolicy) {
-    this(keyProvider, nilPolicy, structuredDataPolicy, EnumSet.of(AllowableDeviations.NONE));
-  }
-
-  /**
-   * Create a new {@code Syslog5424Listener}.
-   *
-   * @param keyProvider          {@link KeyProvider} used for map insertion.
-   * @param nilPolicy            {@link NilPolicy} used for handling nil values.
-   * @param structuredDataPolicy {@link StructuredDataPolicy} used for handling Structured Data
-   *                                                         output.
-   * @param deviations           {@link AllowableDeviations} used for handling abnormalities.
-   */
-  public Syslog5424Listener(KeyProvider keyProvider, NilPolicy nilPolicy,
-                            StructuredDataPolicy structuredDataPolicy,
-                            EnumSet<AllowableDeviations> deviations) {
-    Validate.notNull(keyProvider, "keyProvider");
-    this.keyProvider = keyProvider;
-    if (nilPolicy != null) {
-      this.nilPolicy = nilPolicy;
-    }
-    if (structuredDataPolicy != null) {
-      this.structuredDataPolicy = structuredDataPolicy;
-    }
-    this.deviations = deviations;
-  }
-
-  /**
-   * Returns the {@code Map} of syslog values with the keys as provided by the {@link KeyProvider}.
-   * The map returned is unmodifiable.
-   *
-   * @return unmodifiable {@code Map}
-   */
-  @Override
-  public Map<String, Object> getMessageMap() {
-    if (msgMap.get(keyProvider.getHeaderPriority()) == null && !deviations
-        .contains(AllowableDeviations.PRIORITY)) {
-      throw new ParseException("Priority missing with strict parsing");
-    } else if (msgMap.get(keyProvider.getHeaderVersion()) == null && !deviations
-        .contains(AllowableDeviations.VERSION)) {
-      throw new ParseException("Version missing with strict parsing");
-    }
-    return Collections.unmodifiableMap(msgMap);
+  public Syslog5424Listener(SyslogMessageConsumer syslogBuilder) {
+    this.syslogBuilder = syslogBuilder;
   }
 
   @Override
   public void exitHeaderPriorityValue(Rfc5424Parser.HeaderPriorityValueContext ctx) {
     String priority = ctx.getText();
-    msgMap.put(keyProvider.getHeaderPriority(), priority);
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_PRI, priority);
+
     int pri = Integer.parseInt(priority);
     int sev = pri % 8;
     int facility = pri / 8;
-    msgMap.put(keyProvider.getHeaderSeverity(), String.valueOf(sev));
-    msgMap.put(keyProvider.getHeaderFacility(), String.valueOf(facility));
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_PRI_SEVERITY, String.valueOf(sev));
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_PRI_FACILITY, String.valueOf(facility));
   }
 
   @Override
   public void exitHeaderVersion(Rfc5424Parser.HeaderVersionContext ctx) {
-    msgMap.put(keyProvider.getHeaderVersion(), ctx.getText());
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_VERSION, ctx.getText());
   }
 
   @Override
   public void exitHeaderHostName(Rfc5424Parser.HeaderHostNameContext ctx) {
-    msgMap.put(keyProvider.getHeaderHostName(), ctx.getText());
-
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_HOSTNAME, ctx.getText());
   }
 
   @Override
   public void exitHeaderNilHostName(Rfc5424Parser.HeaderNilHostNameContext ctx) {
-    if (nilPolicy != NilPolicy.OMIT) {
-      handleNil(keyProvider::getHeaderHostName);
-    }
+    syslogBuilder.handleNil(SyslogFieldKeys.HEADER_HOSTNAME);
   }
 
   @Override
   public void exitHeaderAppName(Rfc5424Parser.HeaderAppNameContext ctx) {
-    msgMap.put(keyProvider.getHeaderAppName(), ctx.getText());
-
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_APPNAME, ctx.getText());
   }
 
   @Override
   public void exitHeaderNilAppName(Rfc5424Parser.HeaderNilAppNameContext ctx) {
-    if (nilPolicy != NilPolicy.OMIT) {
-      handleNil(keyProvider::getHeaderAppName);
-    }
+    syslogBuilder.handleNil(SyslogFieldKeys.HEADER_APPNAME);
   }
 
   @Override
   public void exitHeaderProcId(Rfc5424Parser.HeaderProcIdContext ctx) {
-    msgMap.put(keyProvider.getHeaderProcessId(), ctx.getText());
-
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_PROCID, ctx.getText());
   }
 
   @Override
   public void exitHeaderNilProcId(Rfc5424Parser.HeaderNilProcIdContext ctx) {
-    if (nilPolicy != NilPolicy.OMIT) {
-      handleNil(keyProvider::getHeaderProcessId);
-    }
+    syslogBuilder.handleNil(SyslogFieldKeys.HEADER_PROCID);
   }
 
   @Override
   public void exitHeaderMsgId(Rfc5424Parser.HeaderMsgIdContext ctx) {
-    msgMap.put(keyProvider.getHeaderMessageId(), ctx.getText());
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_MSGID, ctx.getText());
   }
 
   @Override
   public void exitHeaderNilMsgId(Rfc5424Parser.HeaderNilMsgIdContext ctx) {
-    if (nilPolicy != NilPolicy.OMIT) {
-      handleNil(keyProvider::getHeaderMessageId);
-    }
+    syslogBuilder.handleNil(SyslogFieldKeys.HEADER_MSGID);
   }
 
   @Override
   public void exitHeaderTimeStamp(Rfc5424Parser.HeaderTimeStampContext ctx) {
-    msgMap.put(keyProvider.getHeaderTimeStamp(),
+    syslogBuilder.consumeValue(SyslogFieldKeys.HEADER_TIMESTAMP,
         ctx.full_date().getText() + "T" + ctx.full_time().getText());
   }
 
   @Override
   public void exitHeaderNilTimestamp(Rfc5424Parser.HeaderNilTimestampContext ctx) {
-    if (nilPolicy != NilPolicy.OMIT) {
-      handleNil(keyProvider::getHeaderTimeStamp);
-    }
+    syslogBuilder.handleNil(SyslogFieldKeys.HEADER_TIMESTAMP);
   }
 
   @SuppressWarnings("unchecked")
   @Override
   public void exitSdElement(Rfc5424Parser.SdElementContext ctx) {
     String id = ctx.sd_id().getText();
-    if (structuredDataPolicy == StructuredDataPolicy.FLATTEN) {
-      for (Rfc5424Parser.Sd_paramContext paramContext : ctx.sd_param()) {
-        msgMap.put(String.format(keyProvider.getStructuredElementIdParamNameFormat(), (id),
-            ((Rfc5424Parser.SdParamContext) paramContext).param_name()
-                .getText()),
-            ((Rfc5424Parser.SdParamContext) paramContext).param_value().getText());
-
-      }
-    } else if (structuredDataPolicy == StructuredDataPolicy.MAP_OF_MAPS) {
-      msgMap.putIfAbsent(keyProvider.getStructuredBase(), new HashMap<String, Object>());
-      Map<String, Object> paramMap = new HashMap<>();
-      for (Rfc5424Parser.Sd_paramContext paramContext : ctx.sd_param()) {
-        paramMap.put(((Rfc5424Parser.SdParamContext) paramContext).param_name().getText(),
-            ((Rfc5424Parser.SdParamContext) paramContext).param_value().getText());
-      }
-      ((Map<String, Object>) msgMap.get(keyProvider.getStructuredBase())).put(id, paramMap);
+    Map<String, String> paramMap = new HashMap<>();
+    for (Rfc5424Parser.Sd_paramContext paramContext : ctx.sd_param()) {
+      paramMap.put(((Rfc5424Parser.SdParamContext) paramContext).param_name().getText(),
+          ((Rfc5424Parser.SdParamContext) paramContext).param_value().getText());
     }
+    syslogBuilder.consumeStructured(id, paramMap);
   }
-
-  /*
-  @Override
-  public void exitMsg_any(Rfc5424Parser.Msg_anyContext ctx) {
-    final String msg = ctx.getText();
-    if (msg != null && !msg.isEmpty()) {
-      msgMap.put(keyProvider.getMessage(), msg.trim());
-    }
-  }
-  */
 
   @Override
   public void exitMsg_utf8(Rfc5424Parser.Msg_utf8Context ctx) {
     final String msg = ctx.getText();
     if (msg != null && !msg.isEmpty()) {
-      msgMap.put(keyProvider.getMessage(), msg.trim());
-    }
-  }
-
-  private void handleNil(Supplier<String> supplier) {
-    if (nilPolicy == NilPolicy.DASH) {
-      msgMap.put(supplier.get(), DASH);
-    } else if (nilPolicy == NilPolicy.NULL) {
-      msgMap.put(supplier.get(), null);
+      syslogBuilder.consumeValue(SyslogFieldKeys.MESSAGE, msg.trim());
     }
   }
 }

--- a/src/main/java/com/github/palindromicity/syslog/dsl/SyslogFieldKeys.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/SyslogFieldKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164BaseListener.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164BaseListener.java
@@ -1,9 +1,10 @@
 // Generated from com/github/palindromicity/syslog/dsl/generated/Rfc3164.g4 by ANTLR 4.7.2
 package com.github.palindromicity.syslog.dsl.generated;
 
+
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164BaseVisitor.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164BaseVisitor.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Lexer.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Lexer.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Listener.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Listener.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Parser.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Parser.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Visitor.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc3164Visitor.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424BaseListener.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424BaseListener.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424BaseVisitor.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424BaseVisitor.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Lexer.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Lexer.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Listener.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Listener.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Parser.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Parser.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Visitor.java
+++ b/src/main/java/com/github/palindromicity/syslog/dsl/generated/Rfc5424Visitor.java
@@ -3,7 +3,7 @@ package com.github.palindromicity.syslog.dsl.generated;
 
 //CHECKSTYLE:OFF
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/github/palindromicity/syslog/util/StructuredDataUtil.java
+++ b/src/main/java/com/github/palindromicity/syslog/util/StructuredDataUtil.java
@@ -12,12 +12,13 @@ public class StructuredDataUtil {
 
   /**
    * Unflattens a flat map such that it contains any nested maps required.
+   *
    * @param flattenedMap the map to unflatten
    * @param keyProvider the key provider to use
    * @return Map
    */
   @SuppressWarnings("unchecked")
-  public static Map<String, Object> unFlattenStructuredData(Map<String, Object> flattenedMap,
+  public static Map<String, Object> unFlattenStructuredData(Map<String, String> flattenedMap,
                                                             KeyProvider keyProvider) {
     Validate.notNull(keyProvider, "keyProvider");
     Validate.notNull(flattenedMap, "flattenedMap");

--- a/src/test/java/com/github/palindromicity/syslog/AbstractRfc3164SyslogParserTest.java
+++ b/src/test/java/com/github/palindromicity/syslog/AbstractRfc3164SyslogParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog-5424 authors
+ * Copyright 2018-2022 simple-syslog-5424 authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,20 +29,20 @@ import org.apache.commons.io.IOUtils;
 
 public abstract class AbstractRfc3164SyslogParserTest {
 
-  protected static List<Map<String, Object>> handleFile(String fileName, SyslogParser parser) throws Exception {
+  protected static List<Map<String, String>> handleFile(String fileName, SyslogParser<Map<String, String>> parser) throws Exception {
     try (Reader reader = new BufferedReader(new FileReader(new File(fileName)))) {
       return parser.parseLines(reader);
     }
   }
 
-  protected static void handleFile(String fileName, SyslogParser parser, Consumer<Map<String, Object>> consumer)
+  protected static void handleFile(String fileName, SyslogParser<Map<String, String>> parser, Consumer<Map<String, String>> consumer)
       throws Exception {
     try (Reader reader = new BufferedReader(new FileReader(new File(fileName)))) {
       parser.parseLines(reader, consumer);
     }
   }
 
-  protected static void handleFile(String fileName, SyslogParser parser, Consumer<Map<String, Object>> consumer,
+  protected static void handleFile(String fileName, SyslogParser<Map<String, String>> parser, Consumer<Map<String, String>> consumer,
       BiConsumer<String,Throwable> errorConsumer)
       throws Exception {
     try (Reader reader = new BufferedReader(new FileReader(new File(fileName)))) {
@@ -50,11 +50,11 @@ public abstract class AbstractRfc3164SyslogParserTest {
     }
   }
 
-  protected static Map<String, Object> handleLine(String line, SyslogParser parser) throws Exception {
+  protected static Map<String, String> handleLine(String line, SyslogParser<Map<String, String>> parser) throws Exception {
     return parser.parseLine(line);
   }
 
-  protected static void handleLine(String line, SyslogParser parser, Consumer<Map<String, Object>> consumer)
+  protected static void handleLine(String line, SyslogParser<Map<String, String>> parser, Consumer<Map<String, String>> consumer)
       throws Exception {
     parser.parseLine(line, consumer);
   }

--- a/src/test/java/com/github/palindromicity/syslog/AbstractRfc5425SyslogParserTest.java
+++ b/src/test/java/com/github/palindromicity/syslog/AbstractRfc5425SyslogParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,20 +27,20 @@ import java.util.function.Consumer;
 
 public abstract class AbstractRfc5425SyslogParserTest {
 
-  protected static List<Map<String, Object>> handleFile(String fileName, SyslogParser parser) throws Exception {
+  protected static List<Map<String, Object>> handleFile(String fileName, SyslogParser<Map<String, Object>> parser) throws Exception {
     try (Reader reader = new BufferedReader(new FileReader(new File(fileName)))) {
       return parser.parseLines(reader);
     }
   }
 
-  protected static void handleFile(String fileName, SyslogParser parser, Consumer<Map<String, Object>> consumer)
+  protected static void handleFile(String fileName, SyslogParser<Map<String, Object>> parser, Consumer<Map<String, Object>> consumer)
       throws Exception {
     try (Reader reader = new BufferedReader(new FileReader(new File(fileName)))) {
       parser.parseLines(reader, consumer);
     }
   }
 
-  protected static void handleFile(String fileName, SyslogParser parser, Consumer<Map<String, Object>> consumer,
+  protected static void handleFile(String fileName, SyslogParser<Map<String, Object>> parser, Consumer<Map<String, Object>> consumer,
       BiConsumer<String,Throwable> errorConsumer)
       throws Exception {
     try (Reader reader = new BufferedReader(new FileReader(new File(fileName)))) {
@@ -48,11 +48,16 @@ public abstract class AbstractRfc5425SyslogParserTest {
     }
   }
 
-  protected static Map<String, Object> handleLine(String line, SyslogParser parser) throws Exception {
+  protected static Map<String, Object> handleLine(String line, SyslogParser<Map<String, Object>> parser) throws Exception {
     return parser.parseLine(line);
   }
 
-  protected static void handleLine(String line, SyslogParser parser, Consumer<Map<String, Object>> consumer)
+  protected static void handleLine(String line, SyslogParser<Map<String, Object>> parser, Consumer<Map<String, Object>> consumer)
+      throws Exception {
+    parser.parseLine(line, consumer);
+  }
+
+  protected static void handleFlatLine(String line, SyslogParser<Map<String, String>> parser, Consumer<Map<String, String>> consumer)
       throws Exception {
     parser.parseLine(line, consumer);
   }

--- a/src/test/java/com/github/palindromicity/syslog/Rfc5424SyslogParserTest.java
+++ b/src/test/java/com/github/palindromicity/syslog/Rfc5424SyslogParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,8 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
 
   @Test
   public void testParseOctetLine() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().forSpecification(SyslogSpecification.RFC_6587_5424).build();
+    MapOfMaps5424MessageHandler builder = new MapOfMaps5424MessageHandler();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String,Object>>().forSpecification(SyslogSpecification.RFC_6587_5424).withSyslogBuilder(builder).build();
     Map<String, Object> map = handleLine(OCTET_MSG, parser);
     Assert.assertNotNull(map);
     Assert.assertEquals("40", map.get(SyslogFieldKeys.HEADER_PRI.getField()));
@@ -100,7 +101,8 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testParseLine() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    MapOfMaps5424MessageHandler builder = new MapOfMaps5424MessageHandler();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     Map<String, Object> map = handleLine(SYSLOG_LINE_ALL, parser);
     Assert.assertEquals(expectedVersion, map.get(SyslogFieldKeys.HEADER_VERSION.getField()));
     Assert.assertEquals(expectedMessage, map.get(SyslogFieldKeys.MESSAGE.getField()));
@@ -114,7 +116,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
     Assert.assertEquals(expectedMessageId, map.get(SyslogFieldKeys.HEADER_MSGID.getField()));
 
     // structured data
-    Map<String, Object> structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
+    Map<String, Object> structured = (Map<String, Object>)map.get(new DefaultKeyProvider().getStructuredBase());
     Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
     Map<String, Object> example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
     Assert.assertTrue(example1.containsKey("iut"));
@@ -137,7 +139,8 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testParseLineEscapedQuote() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    MapOfMaps5424MessageHandler builder = new MapOfMaps5424MessageHandler();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     Map<String, Object> map = handleLine(SYSLOG_LINE_ESC_QUOTES, parser);
     Assert.assertEquals(expectedVersion, map.get(SyslogFieldKeys.HEADER_VERSION.getField()));
     Assert.assertEquals(expectedMessage, map.get(SyslogFieldKeys.MESSAGE.getField()));
@@ -151,7 +154,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
     Assert.assertEquals(expectedMessageId, map.get(SyslogFieldKeys.HEADER_MSGID.getField()));
 
     // structured data
-    Map<String, Object> structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
+    Map<String, Object> structured = (Map<String, Object>) map.get(new DefaultKeyProvider().getStructuredBase());
     Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
     Map<String, Object> example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
     Assert.assertTrue(example1.containsKey("iut"));
@@ -174,7 +177,8 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testParseLineEscapedSlash() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    MapOfMaps5424MessageHandler builder = new MapOfMaps5424MessageHandler();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     Map<String, Object> map = handleLine(SYSLOG_LINE_ESC_SLASH, parser);
     Assert.assertEquals(expectedVersion, map.get(SyslogFieldKeys.HEADER_VERSION.getField()));
     Assert.assertEquals(expectedMessage, map.get(SyslogFieldKeys.MESSAGE.getField()));
@@ -188,7 +192,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
     Assert.assertEquals(expectedMessageId, map.get(SyslogFieldKeys.HEADER_MSGID.getField()));
 
     // structured data
-    Map<String, Object> structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
+    Map<String, Object> structured = (Map<String, Object>) map.get(new DefaultKeyProvider().getStructuredBase());
     Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
     Map<String, Object> example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
     Assert.assertTrue(example1.containsKey("iut"));
@@ -211,7 +215,8 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testParseLineEscapedRightBracket() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    MapOfMaps5424MessageHandler builder = new MapOfMaps5424MessageHandler();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     Map<String, Object> map = handleLine(SYSLOG_LINE_ESC_RIGHT_BRACKET, parser);
     Assert.assertEquals(expectedVersion, map.get(SyslogFieldKeys.HEADER_VERSION.getField()));
     Assert.assertEquals(expectedMessage, map.get(SyslogFieldKeys.MESSAGE.getField()));
@@ -225,7 +230,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
     Assert.assertEquals(expectedMessageId, map.get(SyslogFieldKeys.HEADER_MSGID.getField()));
 
     // structured data
-    Map<String, Object> structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
+    Map<String, Object> structured = (Map<String, Object>) map.get(new DefaultKeyProvider().getStructuredBase());
     Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
     Map<String, Object> example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
     Assert.assertTrue(example1.containsKey("iut"));
@@ -249,7 +254,8 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testParseLineNoMessage() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    MapOfMaps5424MessageHandler builder = new MapOfMaps5424MessageHandler();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     // parse with one SD
     Map<String, Object> map = handleLine(SYSLOG_LINE_NO_MSG, parser);
     Assert.assertEquals(expectedVersion, map.get(SyslogFieldKeys.HEADER_VERSION.getField()));
@@ -264,7 +270,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
     Assert.assertEquals(expectedMessageId, map.get(SyslogFieldKeys.HEADER_MSGID.getField()));
 
     // structured data
-    Map<String, Object> structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
+    Map<String, Object> structured = (Map<String, Object>) map.get(new DefaultKeyProvider().getStructuredBase());
     Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
     Map<String, Object> example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
     Assert.assertTrue(example1.containsKey("iut"));
@@ -289,7 +295,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
     Assert.assertEquals(expectedMessageId, map.get(SyslogFieldKeys.HEADER_MSGID.getField()));
 
     // structured data
-    structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
+    structured = (Map<String, Object>) map.get(new DefaultKeyProvider().getStructuredBase());
     Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
     example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
     Assert.assertTrue(example1.containsKey("iut"));
@@ -313,8 +319,9 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testParseLineConsumer() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
-    handleLine(SYSLOG_LINE_ALL, parser, (map) -> {
+    Flat5424MessageHandler builder = new Flat5424MessageHandler();
+    SyslogParser<Map<String, String>> parser = new SyslogParserBuilder<Map<String, String>>().withSyslogBuilder(builder).build();
+    handleFlatLine(SYSLOG_LINE_ALL, parser, (map) -> {
       Assert.assertEquals(expectedVersion, map.get(SyslogFieldKeys.HEADER_VERSION.getField()));
       Assert.assertEquals(expectedMessage, map.get(SyslogFieldKeys.MESSAGE.getField()));
       Assert.assertEquals(expectedAppName, map.get(SyslogFieldKeys.HEADER_APPNAME.getField()));
@@ -329,7 +336,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
       // structured data
       Map<String, Object> structured = StructuredDataUtil.unFlattenStructuredData(map, new DefaultKeyProvider());
       Assert.assertTrue(structured.containsKey("exampleSDID@32473"));
-      Map<String, Object> example1 = (Map<String, Object>) structured.get("exampleSDID@32473");
+      Map<String, String> example1 = (Map<String, String>) structured.get("exampleSDID@32473");
       Assert.assertTrue(example1.containsKey("iut"));
       Assert.assertTrue(example1.containsKey("eventSource"));
       Assert.assertTrue(example1.containsKey("eventID"));
@@ -352,7 +359,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   public void testParseLinesConsumerAndErrorConsumer() throws Exception {
     final AtomicInteger mapCount = new AtomicInteger();
     final AtomicInteger errorCount = new AtomicInteger();
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     handleFile("src/test/resources/logs/5424/log_all_with_errors.txt", parser, (map) -> mapCount.incrementAndGet(),
         (line, throwable) -> errorCount.incrementAndGet());
     Assert.assertEquals(1, mapCount.get());
@@ -361,14 +368,16 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
 
   @Test
   public void testParseLines() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log_all.txt", parser);
     Assert.assertEquals(1, mapList.size());
   }
 
   @Test
   public void testBomParsing() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().withNilPolicy(NilPolicy.OMIT).withDeviations( EnumSet.of(AllowableDeviations.PRIORITY)).withStructuredDataPolicy(StructuredDataPolicy.MAP_OF_MAPS).build();
+    MapOfMaps5424MessageHandler
+        builder = new MapOfMaps5424MessageHandler(new DefaultKeyProvider(), NilPolicy.OMIT, EnumSet.of(AllowableDeviations.PRIORITY));
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log_with_bom.txt", parser);
     Assert.assertEquals(1, mapList.size());
   }
@@ -376,7 +385,9 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
   //log_utf8_umlauts.txt
   @Test
   public void testBomParsingUmlauts() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().withNilPolicy(NilPolicy.OMIT).withDeviations( EnumSet.of(AllowableDeviations.PRIORITY)).withStructuredDataPolicy(StructuredDataPolicy.MAP_OF_MAPS).build();
+    MapOfMaps5424MessageHandler
+        builder = new MapOfMaps5424MessageHandler(new DefaultKeyProvider(), NilPolicy.OMIT, EnumSet.of(AllowableDeviations.PRIORITY));
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log_utf8_umlauts.txt", parser);
     Assert.assertEquals(1, mapList.size());
     Assert.assertTrue(mapList.get(0).get("syslog.message").toString().contains("äöü"));
@@ -384,28 +395,30 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
 
   @Test
   public void testParseLinesWithDashDefaultPolicy() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log.txt", parser);
     Assert.assertEquals(1, mapList.size());
   }
 
   @Test
   public void testParseLinesWithDashDashPolicy() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().withNilPolicy(NilPolicy.DASH).build();
+    MapOfMaps5424MessageHandler
+        builder = new MapOfMaps5424MessageHandler(new DefaultKeyProvider(), NilPolicy.DASH );
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(builder).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log.txt", parser);
     Assert.assertEquals(1, mapList.size());
   }
 
   @Test
   public void testParseLinesMix() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log_mix.txt", parser);
     Assert.assertEquals(3, mapList.size());
   }
 
   @Test
   public void testParseLinesConsumer() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     final AtomicInteger count = new AtomicInteger();
     handleFile("src/test/resources/logs/5424/log_all.txt",
         parser,
@@ -416,7 +429,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
 
   @Test
   public void testParseLinesConsumerMix() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     final AtomicInteger count = new AtomicInteger();
     handleFile("src/test/resources/logs/5424/log_mix.txt",
         parser,
@@ -427,13 +440,13 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
 
   @Test(expected = ParseException.class)
   public void testInvalidLine() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     handleLine("10 Oct 13 14:14:43 localhost some body of the message", parser);
   }
 
   @Test(expected = ParseException.class)
   public void testInvalidLineConsumer() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     handleLine("10 Oct 13 14:14:43 localhost some body of the message",
         parser,
         (map) -> Assert.fail());
@@ -441,7 +454,7 @@ public class Rfc5424SyslogParserTest extends AbstractRfc5425SyslogParserTest {
 
   @Test
   public void testParseLinesMissingStructure() throws Exception {
-    SyslogParser parser = new SyslogParserBuilder().forSpecification(SyslogSpecification.HEROKU_HTTPS_LOG_DRAIN).build();
+    SyslogParser parser = new SyslogParserBuilder().forSpecification(SyslogSpecification.HEROKU_HTTPS_LOG_DRAIN).withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     List<Map<String, Object>> mapList = handleFile("src/test/resources/logs/5424/log_missing_structure.txt",
       parser);
     Assert.assertEquals(1, mapList.size());

--- a/src/test/java/com/github/palindromicity/syslog/SyslogParserBuilderTest.java
+++ b/src/test/java/com/github/palindromicity/syslog/SyslogParserBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 simple-syslog authors
+ * Copyright 2018-2022 simple-syslog authors
  * All rights reserved.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,24 @@ package com.github.palindromicity.syslog;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.EnumSet;
 
+import java.util.Map;
 import org.junit.Test;
 
 public class SyslogParserBuilderTest {
 
   @Test
   public void testWithSpecification() {
-    SyslogParser parser = new SyslogParserBuilder().forSpecification(SyslogSpecification.RFC_3164)
-        .withDeviations(EnumSet.of(AllowableDeviations.NONE)).build();
+    MapOfMaps5424MessageHandler
+        builder = new MapOfMaps5424MessageHandler(new DefaultKeyProvider(), null);
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().forSpecification(SyslogSpecification.RFC_3164)
+        .withSyslogBuilder(builder).build();
     assertTrue(parser.getClass() == Rfc3164SyslogParser.class);
   }
 
   @Test
   public void testNoSpecification() {
-    SyslogParser parser = new SyslogParserBuilder().build();
+    SyslogParser<Map<String, Object>> parser = new SyslogParserBuilder<Map<String, Object>>().withSyslogBuilder(new MapOfMaps5424MessageHandler()).build();
     assertTrue(parser.getClass() == Rfc5424SyslogParser.class);
   }
 }


### PR DESCRIPTION
SimpleSyslog should not impose the structure of the returned data on the
caller.  Instead the caller should provide a class that implements and
interface and be able to use that to build whatever structure they want.

Doing this makes simple syslog more powerful and better factored, but
not as simple however.

So this PR introduces a new `Simple` class with default implementations
of almost all the `SyslogParser` interface without generics required.

There are breaking changes in this PR, so it will require a major version bump, most likely to 1.0.0

Fixes #19